### PR TITLE
Type Checking through Unification

### DIFF
--- a/elab.cabal
+++ b/elab.cabal
@@ -19,6 +19,7 @@ library
   exposed-modules:     Elab.Check
                      , Elab.Elab
                      , Elab.Name
+                     , Elab.Pretty
                      , Elab.Stack
                      , Elab.Term
                      , Elab.Type

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -9,9 +9,9 @@ import Elab.Type (Type)
 import Prelude hiding (fail, pi)
 
 elab :: Term Name -> Elab (Value Meta ::: Type Meta)
-elab (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
-elab (Head (Free v))  = assume v
-elab (Lam b)          = intro (\ n -> elab (instantiate (pure n) b))
-elab (f :$ a)         = elab f $$ elab a
-elab Type             = type'
-elab (Pi t b)         = pi (elab t) (\ n -> elab (instantiate (pure n) b))
+elab (Var (Bound i)) = fail ("Unexpected bound variable " ++ show i)
+elab (Var (Free v))  = assume v
+elab (Lam b)         = intro (\ n -> elab (instantiate (pure n) b))
+elab (f :$ a)        = elab f $$ elab a
+elab Type            = type'
+elab (Pi t b)        = pi (elab t) (\ n -> elab (instantiate (pure n) b))

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -13,7 +13,7 @@ check t          = switch (infer t)
 
 infer :: Term Name -> Infer (Typed Name Value)
 infer (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
-infer (Head (Free v))  = assumption v
+infer (Head (Free v))  = assume v
 infer (f :$ a)         = infer f $$ check a
 infer Type             = type'
 infer (Pi t body)      = pi (check t) (\ name -> check (instantiate (pure name) body))

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -8,22 +8,10 @@ import Elab.Term (Term(..), instantiate)
 import Elab.Type (Type)
 import Prelude hiding (fail, pi)
 
-check :: Term Name -> Check (Value Name ::: Type Name)
-check (Lam body) = intro (\ name -> check (instantiate (pure name) body))
-check t          = switch (infer t)
-
-infer :: Term Name -> Infer (Value Name ::: Type Name)
-infer (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
-infer (Head (Free v))  = assume v
-infer (f :$ a)         = infer f $$ check a
-infer Type             = type'
-infer (Pi t body)      = pi (check t) (\ name -> check (instantiate (pure name) body))
-infer t                = fail ("No rule to infer type of term " ++ show t)
-
 elab :: Term Name -> Elab (Value Meta ::: Type Meta)
 elab (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
-elab (Head (Free v))  = assume' v
-elab (Lam b)          = intro' (\ n -> elab (instantiate (pure n) b))
-elab (f :$ a)         = elab f $$$ elab a
-elab Type             = type''
-elab (Pi t b)         = pi' (elab t) (\ n -> elab (instantiate (pure n) b))
+elab (Head (Free v))  = assume v
+elab (Lam b)          = intro (\ n -> elab (instantiate (pure n) b))
+elab (f :$ a)         = elab f $$ elab a
+elab Type             = type'
+elab (Pi t b)         = pi (elab t) (\ n -> elab (instantiate (pure n) b))

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -8,7 +8,7 @@ import Elab.Type (Typed(..))
 import Prelude hiding (fail, pi)
 
 check :: Term Name -> Check (Typed Name Value)
-check (Lam body) = introduce (\ name -> check (instantiate (pure name) body))
+check (Lam body) = intro (\ name -> check (instantiate (pure name) body))
 check t          = switch (infer t)
 
 infer :: Term Name -> Infer (Typed Name Value)

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -1,17 +1,18 @@
+{-# LANGUAGE TypeOperators #-}
 module Elab.Check where
 
 import Control.Monad.Fail
 import Elab.Elab
 import Elab.Name
 import Elab.Term (Term(..), instantiate)
-import Elab.Type (Typed(..))
+import Elab.Type ((:::)(..), Type)
 import Prelude hiding (fail, pi)
 
-check :: Term Name -> Check (Typed Name Value)
+check :: Term Name -> Check (Value ::: Type Name)
 check (Lam body) = intro (\ name -> check (instantiate (pure name) body))
 check t          = switch (infer t)
 
-infer :: Term Name -> Infer (Typed Name Value)
+infer :: Term Name -> Infer (Value ::: Type Name)
 infer (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
 infer (Head (Free v))  = assume v
 infer (f :$ a)         = infer f $$ check a

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -5,7 +5,7 @@ import Control.Monad.Fail
 import Elab.Elab
 import Elab.Name
 import Elab.Term (Term(..), instantiate)
-import Elab.Type ((:::)(..), Type)
+import Elab.Type (Type)
 import Prelude hiding (fail, pi)
 
 check :: Term Name -> Check (Value ::: Type Name)

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -8,11 +8,11 @@ import Elab.Term (Term(..), instantiate)
 import Elab.Type (Type)
 import Prelude hiding (fail, pi)
 
-check :: Term Name -> Check (Value ::: Type Name)
+check :: Term Name -> Check (Value Name ::: Type Name)
 check (Lam body) = intro (\ name -> check (instantiate (pure name) body))
 check t          = switch (infer t)
 
-infer :: Term Name -> Infer (Value ::: Type Name)
+infer :: Term Name -> Infer (Value Name ::: Type Name)
 infer (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
 infer (Head (Free v))  = assume v
 infer (f :$ a)         = infer f $$ check a

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -19,3 +19,11 @@ infer (f :$ a)         = infer f $$ check a
 infer Type             = type'
 infer (Pi t body)      = pi (check t) (\ name -> check (instantiate (pure name) body))
 infer t                = fail ("No rule to infer type of term " ++ show t)
+
+elab :: Term Name -> Elab (Value Meta ::: Type Meta)
+elab (Head (Bound i)) = fail ("Unexpected bound variable " ++ show i)
+elab (Head (Free v))  = assume' v
+elab (Lam b)          = intro' (\ n -> elab (instantiate (pure n) b))
+elab (f :$ a)         = elab f $$$ elab a
+elab Type             = type''
+elab (Pi t b)         = pi' (elab t) (\ n -> elab (instantiate (pure n) b))

--- a/src/Elab/Check.hs
+++ b/src/Elab/Check.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TypeOperators #-}
 module Elab.Check where
 
-import Control.Monad.Fail
 import Elab.Elab
 import Elab.Name
 import Elab.Term (Term(..), instantiate)
@@ -9,9 +8,8 @@ import Elab.Type (Type)
 import Prelude hiding (fail, pi)
 
 elab :: Term Name -> Elab (Value Meta ::: Type Meta)
-elab (Var (Bound i)) = fail ("Unexpected bound variable " ++ show i)
-elab (Var (Free v))  = assume v
-elab (Lam b)         = intro (\ n -> elab (instantiate (pure n) b))
-elab (f :$ a)        = elab f $$ elab a
-elab Type            = type'
-elab (Pi t b)        = pi (elab t) (\ n -> elab (instantiate (pure n) b))
+elab (Var v)  = assume v
+elab (Lam b)  = intro (\ n -> elab (instantiate (pure n) b))
+elab (f :$ a) = elab f $$ elab a
+elab Type     = type'
+elab (Pi t b) = pi (elab t) (\ n -> elab (instantiate (pure n) b))

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -228,6 +228,10 @@ simplify (ctx :|-: c) = execWriter (go c)
             n <- Name . Local <$> gensym "simplify"
             -- FIXME: this should probably extend the context while simplifying the body
             go ((Type.instantiate (pure n) f1 :===: Type.instantiate (pure n) f2) ::: Type.instantiate (pure n) b)
+          (Free (Name n) :$ sp :===: tm2) ::: ty | Just tm1 <- Map.lookup n ctx -> do
+            go ((tm1 Type.$$* sp :===: tm2) ::: ty)
+          (tm1 :===: Free (Name n) :$ sp) ::: ty | Just tm2 <- Map.lookup n ctx -> do
+            go ((tm1 :===: tm2 Type.$$* sp) ::: ty)
           c@((t1 :===: t2) ::: _)
             | stuck t1 || stuck t2 -> tell (Set.singleton (ctx :|-: c))
             | otherwise            -> fail ("unsimplifiable constraint: " ++ show c)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -87,6 +87,16 @@ runCheck' :: Context -> Type Name -> Check a -> Either String a
 runCheck' sig ty = runInfer' sig . ascribe ty
 
 
+
+
+exists :: (Carrier sig m, Member Fresh sig, Member (Reader Context) sig, Member (Reader Gensym) sig) => Type Name -> m (Value ::: Type Name)
+exists ty = do
+  ctx <- ask
+  -- FIXME: add meta names
+  n <- Gensym <$> gensym "_meta_"
+  pure (pure n Type.$$* fmap pure (Map.keys (ctx :: Context)) ::: ty)
+
+
 data Equation a
   = a :===: a
   deriving (Eq, Ord, Show)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -181,7 +181,7 @@ runElab ty (Elab m) = run . runFail $ do
   evalState (Seq.empty :: Seq.Seq (Contextual (Equation (Value Meta ::: Type Meta)))) $ do
     stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set (Contextual (Equation (Value Meta ::: Type Meta))))) $ do
       modify (flip (foldl' (Seq.|>)) constraints)
-      step
+      pure ()
     unless (null stuck) $ fail ("stuck metavariables: " ++ show stuck)
     let subst = Map.empty
     val' <- substitute subst val

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -27,12 +27,12 @@ assume v = Infer $ do
   sig <- ask
   maybe (fail ("Variable not in scope: " <> show v)) (pure . (pure v :::)) (Map.lookup v sig)
 
-introduce :: (Name -> Check (Typed Name Value)) -> Check (Typed Name Value)
-introduce body = do
+intro :: (Name -> Check (Typed Name Value)) -> Check (Typed Name Value)
+intro body = do
   expected <- goal
   case expected of
     Pi t b -> Check $ do
-      x <- Gensym <$> gensym "introduce"
+      x <- Gensym <$> gensym "intro"
       b' ::: bT <- x ::: t |- runCheck (goalIs (Type.instantiate (pure x) b) (body x))
       pure (Type.lam x b' ::: Type.pi (x ::: t) bT)
     _ -> fail ("expected function type, got " <> show expected)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -160,7 +160,7 @@ a ::: ty ||- Elab m = Elab (local (Map.insert a ty) m)
 infix 5 ||-
 
 unify :: Equation (Value Meta ::: Type Meta) -> Elab ()
-unify constraint = context >>= Elab . tell . Set.singleton . (:|- constraint)
+unify constraint = context >>= Elab . tell . Set.singleton . (:|-: constraint)
 
 
 data Equation a
@@ -169,10 +169,10 @@ data Equation a
 
 infix 3 :===:
 
-data Contextual a = Context (Type Meta) :|- a
+data Contextual a = Context (Type Meta) :|-: a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
-infixr 1 :|-
+infixr 1 :|-:
 
 
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
@@ -181,7 +181,7 @@ runElab ty (Elab m) = run . runFail $ do
   evalState (Seq.empty :: Seq.Seq (Contextual (Equation (Value Meta ::: Type Meta)))) $ do
     stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set (Contextual (Equation (Value Meta ::: Type Meta))))) $ do
       modify (flip (foldl' (Seq.|>)) constraints)
-      pure ()
+      step
     unless (null stuck) $ fail ("stuck metavariables: " ++ show stuck)
     let subst = Map.empty
     val' <- substitute subst val

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -224,6 +224,11 @@ simplify (ctx :|-: c) = execWriter (go c)
             go (t1 ::: Type :===: t2 ::: Type)
             n <- Name . Local <$> gensym "simplify"
             go (Type.instantiate (pure n) b1 ::: Type :===: Type.instantiate (pure n) b2 ::: Type)
+          Lam f1 ::: Pi t1 b1 :===: Lam f2 ::: Pi t2 b2 -> do
+            go (Pi t1 b1 ::: Type :===: Pi t2 b2 ::: Type)
+            n <- Name . Local <$> gensym "simplify"
+            -- FIXME: this should probably extend the context while simplifying the body
+            go (Type.instantiate (pure n) f1 ::: Type.instantiate (pure n) b1 :===: Type.instantiate (pure n) f2 ::: Type.instantiate (pure n) b2)
           c@(t1 :===: t2)
             | stuck t1 || stuck t2 -> tell (Set.singleton (ctx :|-: c))
             | otherwise            -> fail ("unsimplifiable constraint: " ++ show c)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -116,10 +116,10 @@ freshName :: String -> Elab Name
 freshName s = Gensym <$> Elab (gensym s)
 
 exists :: Type Name -> Elab (Value ::: Type Name)
-exists ty = Elab $ do
-  ctx <- ask
+exists ty = do
+  ctx <- Elab ask
   -- FIXME: add meta names
-  n <- Gensym <$> gensym "_meta_"
+  n <- freshName "_meta_"
   pure (pure n Type.$$* fmap pure (Map.keys (ctx :: Context)) ::: ty)
 
 goal' :: Elab (Type Name)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -89,12 +89,12 @@ runCheck' :: Context -> Type Name -> Check a -> Either String a
 runCheck' sig ty = runInfer' sig . ascribe ty
 
 
-newtype Elab a = Elab { runElab :: ReaderC Context (ReaderC Gensym (FreshC (WriterC (Set.Set (Contextual (Equation (Value ::: Type Name)))) (FailC VoidC)))) a }
+newtype Elab a = Elab { runElab :: ReaderC (Type Name) (ReaderC Context (ReaderC Gensym (FreshC (WriterC (Set.Set (Contextual (Equation (Value ::: Type Name)))) (FailC VoidC))))) a }
   deriving (Applicative, Functor, Monad, MonadFail)
 
-assume' :: Name ::: Type Name -> Elab (Value ::: Type Name)
-assume' (v ::: ty) = Elab $ do
-  a ::: ty <- exists ty
+assume' :: Name -> Elab (Value ::: Type Name)
+assume' v = Elab $ do
+  a ::: ty <- ask >>= exists
   _A <- lookupVar v
   ctx <- ask
   tell (Set.singleton (ctx :|- pure v ::: _A :===: a ::: ty))

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -108,6 +108,9 @@ exists ty = do
   n <- Gensym <$> gensym "_meta_"
   pure (pure n Type.$$* fmap pure (Map.keys (ctx :: Context)) ::: ty)
 
+goal' :: Elab (Type Name)
+goal' = Elab ask
+
 
 data Equation a
   = a :===: a

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -144,6 +144,7 @@ step = do
 
 process :: (Carrier sig m, Effect sig, Member Fresh sig, Member (Reader Gensym) sig, Member (State Blocked) sig, Member (State Queue) sig, Member (State Substitution) sig, MonadFail m) => Substitution -> HomConstraint -> m ()
 process _S c@(_ :|-: (tm1 :===: tm2) ::: ty)
+  | tm1 == tm2 = pure ()
   | s <- Map.restrictKeys _S (metaNames (fvs c)), not (null s) = simplify (applyConstraint s c) >>= enqueueAll
   | Just (m, sp) <- pattern tm1 = solve (m := Type.lams sp tm2) >> get >>= \ _S -> process _S c
   | Just (m, sp) <- pattern tm2 = solve (m := Type.lams sp tm1) >> get >>= \ _S -> process _S c

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -222,6 +222,7 @@ simplify (ctx :|-: c) = execWriter (go c)
           (Pi t1 b1 :===: Pi t2 b2) ::: Type -> do
             go ((t1 :===: t2) ::: Type)
             n <- Name . Local <$> gensym "simplify"
+            -- FIXME: this should probably extend the context while simplifying the body
             go ((Type.instantiate (pure n) b1 :===: Type.instantiate (pure n) b2) ::: Type)
           (Lam f1 :===: Lam f2) ::: Pi t b -> do
             n <- Name . Local <$> gensym "simplify"

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -107,6 +107,10 @@ data Contextual a = Context (Type Meta) :|-: a
 
 infixr 1 :|-:
 
+instance Pretty a => Pretty (Contextual a) where
+  prettys (ctx :|-: a) = showString "Γ " . prettys ctx . showString " ⊢ " . prettys a
+
+
 type HetConstraint = Contextual (Equation (Value Meta ::: Type Meta))
 type HomConstraint = Contextual (Equation (Value Meta) ::: Type Meta)
 type Blocked = Map.Map Gensym (Set.Set HomConstraint)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -102,6 +102,10 @@ data Equation a
 
 infix 3 :===:
 
+instance Pretty a => Pretty (Equation a) where
+  prettys (a1 :===: a2) = prettys a1 . showString " ≡ " . prettys a2
+
+
 data Contextual a = Context (Type Meta) :|-: a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -275,11 +275,11 @@ simplify :: ( Carrier sig m
             )
          => Constraint
          -> m (Set.Set Constraint)
-simplify = execWriter . go
+simplify (_ :|-: c) = execWriter (go c)
   where go = \case
-          _   :|-: tm1 ::: ty1 :===: tm2 ::: ty2 | tm1 == tm2, ty1 == ty2 -> pure ()
-          ctx :|-: Pi t1 b1 ::: Type :===: Pi t2 b2 ::: Type -> do
-            go (ctx :|-: t1 ::: Type :===: t2 ::: Type)
+          tm1 ::: ty1 :===: tm2 ::: ty2 | tm1 == tm2, ty1 == ty2 -> pure ()
+          Pi t1 b1 ::: Type :===: Pi t2 b2 ::: Type -> do
+            go (t1 ::: Type :===: t2 ::: Type)
             n <- Name . Local <$> gensym "simplify"
-            go (ctx :|-: Type.instantiate (pure n) b1 ::: Type :===: Type.instantiate (pure n) b2 ::: Type)
+            go (Type.instantiate (pure n) b1 ::: Type :===: Type.instantiate (pure n) b2 ::: Type)
           c -> fail ("unsimplifiable constraint: " ++ show c)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, GeneralizedNewtypeDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveTraversable, FlexibleContexts, GeneralizedNewtypeDeriving, TypeOperators #-}
 module Elab.Elab where
 
 import Control.Effect
@@ -85,3 +85,10 @@ runInfer' sig = run . runFail . runFresh . runReader (Root "root") . runReader s
 
 runCheck' :: Context -> Type Name -> Check a -> Either String a
 runCheck' sig ty = runInfer' sig . ascribe ty
+
+
+data Equation a
+  = a :===: a
+  deriving (Eq, Ord, Show)
+
+infix 3 :===:

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -175,6 +175,10 @@ data Contextual a = Context (Type Meta) :|-: a
 infixr 1 :|-:
 
 type Constraint = Contextual (Equation (Value Meta ::: Type Meta))
+type Blocked = Map.Map Gensym (Set.Set Constraint)
+type Substitution = Map.Map Gensym (Value Meta)
+type Queue = Seq.Seq Constraint
+
 
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
 runElab ty (Elab m) = run . runFail $ do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -179,6 +179,11 @@ type Blocked = Map.Map Gensym (Set.Set Constraint)
 type Substitution = Map.Map Gensym (Value Meta)
 type Queue = Seq.Seq Constraint
 
+data Solution
+  = Gensym := Value Meta
+  deriving (Eq, Ord, Show)
+
+infix 5 :=
 
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
 runElab ty (Elab m) = run . runFail $ do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -19,6 +19,7 @@ import Elab.Stack
 import Elab.Type (Type(..))
 import qualified Elab.Type as Type
 import Prelude hiding (fail)
+import Text.Show
 
 type Context = Map.Map Name
 type Value = Type
@@ -112,7 +113,8 @@ data Contextual a = Context (Type Meta) :|-: a
 infixr 1 :|-:
 
 instance Pretty a => Pretty (Contextual a) where
-  prettys (ctx :|-: a) = showString "Γ " . prettys ctx . showString " ⊢ " . prettys a
+  prettys (ctx :|-: a) = showString "Γ " . showListWith prettyBinding (Map.toList ctx) . showString " ⊢ " . prettys a
+    where prettyBinding (v, t) = prettys v . showString " : " . prettys t
 
 
 type HetConstraint = Contextual (Equation (Value Meta ::: Type Meta))

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -103,7 +103,6 @@ assume' v = do
 intro' :: (Name -> Elab (Value ::: Type Name)) -> Elab (Value ::: Type Name)
 intro' body = do
   a ::: ty <- goal' >>= exists
-
   _A ::: _ <- exists Type
   x <- gensym' "intro"
   _B ::: _ <- x ::: _A ||- exists Type

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -180,12 +180,12 @@ dequeue = gets Seq.viewl >>= \case
   h Seq.:< q -> Just h <$ put q
 
 pattern :: Type Meta -> Maybe (Gensym, Stack Meta)
-pattern (Free (Meta m) :$ sp) = (,) m <$> (traverse free sp >>= distinct)
-pattern _                     = Nothing
+pattern (Meta m :$ sp) = (,) m <$> (traverse free sp >>= distinct)
+pattern _              = Nothing
 
 free :: Type a -> Maybe a
-free (Free v :$ Nil) = Just v
-free _               = Nothing
+free (v :$ Nil) = Just v
+free _          = Nothing
 
 distinct :: (Foldable t, Ord a) => t a -> Maybe (t a)
 distinct sp = sp <$ guard (length (foldMap Set.singleton sp) == length sp)
@@ -248,8 +248,8 @@ simplify = execWriter . go
             | stuck t1 || stuck t2 -> tell (Set.singleton c)
             | otherwise            -> fail ("unsimplifiable constraint: " ++ pretty c)
 
-        stuck (Free (Meta _) :$ _) = True
-        stuck _                    = False
+        stuck (Meta _ :$ _) = True
+        stuck _             = False
 
 hetToHom :: HetConstraint -> Set.Set HomConstraint
 hetToHom (ctx :|-: tm1 ::: ty1 :===: tm2 ::: ty2) = Set.fromList

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -148,10 +148,10 @@ goal' :: Elab (Type Meta)
 goal' = Elab ask
 
 goalIs' :: Type Meta -> Elab a -> Elab a
-goalIs' ty = Elab . local (const ty) . runElab
+goalIs' ty (Elab m) = Elab (local (const ty) m)
 
 (||-) :: Name ::: Type Meta -> Elab a -> Elab a
-a ::: ty ||- m = Elab (local (Map.insert a ty) (runElab m))
+a ::: ty ||- Elab m = Elab (local (Map.insert a ty) m)
 
 infix 5 ||-
 

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -199,8 +199,8 @@ runElab ty m = run . runFail . runFresh . runReader (Root "elab") $ do
   pure (val' ::: ty')
 
 solver :: (Carrier sig m, Effect sig, Member Fresh sig, Member (Reader Gensym) sig, MonadFail m) => Set.Set Constraint -> m Substitution
-solver constraints = execState Map.empty . evalState (Seq.empty :: Seq.Seq Constraint) $ do
-  stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set Constraint)) $ do
+solver constraints = execState Map.empty . evalState (Seq.empty :: Queue) $ do
+  stuck <- fmap fold . execState (Map.empty :: Blocked) $ do
     enqueueAll constraints
     step
   unless (null stuck) $ fail ("stuck constraints: " ++ show stuck)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -197,10 +197,6 @@ runElab ty (Elab m) = run . runFail $ do
           Meta m -> maybe (fail ("unsolved metavariable " ++ show m)) pure (Map.lookup m subst)
 
 simplify :: ( Carrier sig m
-            , Effect sig
-            , Member Fresh sig
-            , Member (Reader (Context (Type Meta))) sig
-            , Member (Reader Gensym) sig
             , MonadFail m
             )
          => Constraint

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -111,6 +111,9 @@ exists ty = do
 goal' :: Elab (Type Name)
 goal' = Elab ask
 
+goalIs' :: Type Name -> Elab a -> Elab a
+goalIs' ty = Elab . local (const ty) . runElab
+
 
 data Equation a
   = a :===: a

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -105,13 +105,16 @@ intro' body = do
   a ::: ty <- goal' >>= exists
 
   _A ::: _ <- exists Type
-  x <- Elab (Gensym <$> gensym "intro")
+  x <- gensym' "intro"
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
   ctx <- Elab ask
   unify (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)
   pure (a ::: ty)
 
+
+gensym' :: String -> Elab Name
+gensym' s = Gensym <$> Elab (gensym s)
 
 exists :: Type Name -> Elab (Value ::: Type Name)
 exists ty = Elab $ do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -24,8 +24,8 @@ newtype Infer a = Infer { runInfer :: ReaderC Signature (ReaderC Gensym (FreshC 
 
 assume :: Name -> Infer (Value ::: Type Name)
 assume v = Infer $ do
-  sig <- ask
-  maybe (fail ("Variable not in scope: " <> show v)) (pure . (pure v :::)) (Map.lookup v sig)
+  ty <- asks (Map.lookup v)
+  maybe (fail ("Variable not in scope: " <> show v)) (pure . (pure v :::)) ty
 
 intro :: (Name -> Check (Value ::: Type Name)) -> Check (Value ::: Type Name)
 intro body = do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -87,11 +87,11 @@ lookupVar :: (Carrier sig m, Member (Reader (Context ty)) sig, MonadFail m) => N
 lookupVar v = asks (Map.lookup v) >>= maybe (fail ("Variable not in scope: " <> show v)) pure
 
 
-runInfer :: Context (Type Name) -> Infer a -> Either String a
-runInfer sig = run . runFail . runFresh . runReader (Root "root") . runReader sig  . unInfer
+runInfer :: Infer a -> Either String a
+runInfer = run . runFail . runFresh . runReader (Root "root") . runReader mempty  . unInfer
 
-runCheck :: Context (Type Name) -> Type Name -> Check a -> Either String a
-runCheck sig ty = runInfer sig . ascribe ty
+runCheck :: Type Name -> Check a -> Either String a
+runCheck ty = runInfer . ascribe ty
 
 
 newtype Elab a = Elab { unElab :: ReaderC (Type Meta) (ReaderC (Context (Type Meta)) (WriterC (Set.Set Constraint) (ReaderC Gensym (FreshC (FailC VoidC))))) a }

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -8,7 +8,7 @@ import Control.Effect.Reader
 import Control.Monad (unless)
 import qualified Data.Map as Map
 import Elab.Name
-import Elab.Type (Type(..), (:::)(..))
+import Elab.Type (Type(..))
 import qualified Elab.Type as Type
 import Prelude hiding (fail)
 

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -147,7 +147,7 @@ exists ty = do
   ctx <- context
   -- FIXME: add meta names
   n <- freshName "meta"
-  pure (pure n Type.$$* fmap pure (Map.keys (ctx :: Context)) ::: ty)
+  pure (pure n Type.$$* map pure (Map.keys (ctx :: Context)) ::: ty)
 
 goal' :: Elab (Type Name)
 goal' = Elab ask

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -107,6 +107,7 @@ data Contextual a = Context (Type Meta) :|-: a
 infixr 1 :|-:
 
 type HetConstraint = Contextual (Equation (Value Meta ::: Type Meta))
+type HomConstraint = Contextual (Equation (Value Meta) ::: Type Meta)
 type Blocked = Map.Map Gensym (Set.Set HetConstraint)
 type Substitution = Map.Map Gensym (Value Meta)
 type Queue = Seq.Seq HetConstraint

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -115,6 +115,15 @@ type'' = do
   unify (Type ::: Type :===: a ::: ty)
   pure (a ::: ty)
 
+pi' :: Elab (Value ::: Type Name) -> (Name -> Elab (Value ::: Type Name)) -> Elab (Value ::: Type Name)
+pi' t body = do
+  a ::: ty <- goal' >>= exists
+  t' ::: _ <- goalIs' Type t
+  x <- freshName "pi"
+  b' ::: _ <- x ::: t' ||- goalIs' Type (body x)
+  unify (Type.pi (x ::: t') b' ::: Type :===: a ::: ty)
+  pure (a ::: ty)
+
 
 freshName :: String -> Elab Name
 freshName s = Gensym <$> Elab (gensym s)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -114,6 +114,11 @@ goal' = Elab ask
 goalIs' :: Type Name -> Elab a -> Elab a
 goalIs' ty = Elab . local (const ty) . runElab
 
+(||-) :: Name ::: Type Name -> Elab a -> Elab a
+a ::: ty ||- m = Elab (local (Map.insert a ty) (runElab m))
+
+infix 5 ||-
+
 
 data Equation a
   = a :===: a

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -96,7 +96,7 @@ assume' :: Name -> Elab (Value ::: Type Name)
 assume' v = do
   a ::: ty <- goal' >>= exists
   _A <- Elab (lookupVar v)
-  ctx <- Elab ask
+  ctx <- context
   unify (ctx :|- pure v ::: _A :===: a ::: ty)
   pure (a ::: ty)
 
@@ -107,7 +107,7 @@ intro' body = do
   x <- freshName "intro"
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
-  ctx <- Elab ask
+  ctx <- context
   unify (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)
   pure (a ::: ty)
 
@@ -115,9 +115,12 @@ intro' body = do
 freshName :: String -> Elab Name
 freshName s = Gensym <$> Elab (gensym s)
 
+context :: Elab Context
+context = Elab ask
+
 exists :: Type Name -> Elab (Value ::: Type Name)
 exists ty = do
-  ctx <- Elab ask
+  ctx <- context
   -- FIXME: add meta names
   n <- freshName "_meta_"
   pure (pure n Type.$$* fmap pure (Map.keys (ctx :: Context)) ::: ty)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -97,7 +97,7 @@ assume' v = do
   a ::: ty <- goal' >>= exists
   _A <- Elab (lookupVar v)
   ctx <- Elab ask
-  Elab (tell (Set.singleton (ctx :|- pure v ::: _A :===: a ::: ty)))
+  unify (ctx :|- pure v ::: _A :===: a ::: ty)
   pure (a ::: ty)
 
 intro' :: (Name -> Elab (Value ::: Type Name)) -> Elab (Value ::: Type Name)
@@ -109,7 +109,7 @@ intro' body = do
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
   ctx <- Elab ask
-  Elab (tell (Set.singleton (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)))
+  unify (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)
   pure (a ::: ty)
 
 
@@ -130,6 +130,9 @@ goalIs' ty = Elab . local (const ty) . runElab
 a ::: ty ||- m = Elab (local (Map.insert a ty) (runElab m))
 
 infix 5 ||-
+
+unify :: Contextual (Equation (Value ::: Type Name)) -> Elab ()
+unify = Elab . tell . Set.singleton
 
 
 data Equation a

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -187,9 +187,12 @@ data Solution
 infix 5 :=
 
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
-runElab ty (Elab m) = run . runFail . runFresh . runReader (Root "elab") $ do
-  mTy <- Name . Local <$> gensym "meta"
-  (constraints, val ::: ty) <- runWriter (runReader (mempty :: Context (Type Meta)) (runReader (fromMaybe (pure mTy) ty) m))
+runElab ty m = run . runFail . runFresh . runReader (Root "elab") $ do
+  ty' <- maybe (pure . Meta <$> gensym "meta") pure ty
+  (constraints, val ::: ty) <- runWriter . runReader (mempty :: Context (Type Meta)) . runReader ty' . unElab $ do
+    val <- exists ty'
+    m' <- m
+    m' <$ unify (m' :===: val)
   subst <- execState (Map.empty :: Map.Map Gensym (Value Meta)) . evalState (Seq.empty :: Seq.Seq Constraint) $ do
     stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set Constraint)) $ do
       enqueueAll constraints

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -12,7 +12,6 @@ import Elab.Type (Type(..))
 import qualified Elab.Type as Type
 import Prelude hiding (fail)
 
-type Context = [Type Name]
 type Signature = Map.Map Name (Type Name)
 type Value = Type Name
 

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -197,7 +197,7 @@ runElab ty m = run . runFail . runFresh . runReader (Root "elab") $ do
     stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set Constraint)) $ do
       enqueueAll constraints
       step
-    unless (null stuck) $ fail ("stuck metavariables: " ++ show stuck)
+    unless (null stuck) $ fail ("stuck constraints: " ++ show stuck)
   val' <- substTy subst val
   ty' <- substTy subst ty
   pure (val' ::: ty')

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -135,7 +135,7 @@ exists :: Type Name -> Elab (Value ::: Type Name)
 exists ty = do
   ctx <- context
   -- FIXME: add meta names
-  n <- freshName "_meta_"
+  n <- freshName "meta"
   pure (pure n Type.$$* fmap pure (Map.keys (ctx :: Context)) ::: ty)
 
 goal' :: Elab (Type Name)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -4,7 +4,7 @@ module Elab.Elab where
 import Control.Effect
 import Control.Effect.Fail
 import Control.Effect.Fresh
-import Control.Effect.Reader
+import Control.Effect.Reader hiding (Local)
 import Control.Effect.Writer
 import Control.Monad (unless)
 import qualified Data.Map as Map
@@ -31,7 +31,7 @@ intro body = do
   expected <- goal
   case expected of
     Pi t b -> Check $ do
-      x <- Gensym <$> gensym "intro"
+      x <- Local <$> gensym "intro"
       b' ::: bT <- x ::: t |- runCheck (goalIs (Type.instantiate (pure x) b) (body x))
       pure (Type.lam x b' ::: Type.pi (x ::: t) bT)
     _ -> fail ("expected function type, got " <> show expected)
@@ -42,7 +42,7 @@ type' = pure (Type ::: Type)
 pi :: Check (Value ::: Type Name) -> (Name -> Check (Value ::: Type Name)) -> Infer (Value ::: Type Name)
 pi t body = do
   t' ::: _ <- ascribe Type t
-  x <- Infer (Gensym <$> gensym "pi")
+  x <- Infer (Local <$> gensym "pi")
   body' ::: _ <- Infer (x ::: t' |- runInfer (ascribe Type (body x)))
   pure (Type.pi (x ::: t') body' ::: Type)
 
@@ -137,7 +137,7 @@ f $$$ a = do
 
 
 freshName :: String -> Elab Name
-freshName s = Gensym <$> Elab (gensym s)
+freshName s = Local <$> Elab (gensym s)
 
 context :: Elab Context
 context = Elab ask

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -221,13 +221,12 @@ simplify = execWriter . go
           ctx :|-: (tm1 :===: tm2) ::: _ | tm1 == tm2 -> pure ()
           ctx :|-: (Pi t1 b1 :===: Pi t2 b2) ::: Type -> do
             go (ctx :|-: (t1 :===: t2) ::: Type)
-            n <- Name . Local <$> gensym "simplify"
-            -- FIXME: this should probably extend the context while simplifying the body
-            go (ctx :|-: (Type.instantiate (pure n) b1 :===: Type.instantiate (pure n) b2) ::: Type)
+            n <- Local <$> gensym "simplify"
+            -- FIXME: this should insert some sort of dependency
+            go (Map.insert n t1 ctx :|-: (Type.instantiate (pure (Name n)) b1 :===: Type.instantiate (pure (Name n)) b2) ::: Type)
           ctx :|-: (Lam f1 :===: Lam f2) ::: Pi t b -> do
-            n <- Name . Local <$> gensym "simplify"
-            -- FIXME: this should probably extend the context while simplifying the body
-            go (ctx :|-: (Type.instantiate (pure n) f1 :===: Type.instantiate (pure n) f2) ::: Type.instantiate (pure n) b)
+            n <- Local <$> gensym "simplify"
+            go (Map.insert n t ctx :|-: (Type.instantiate (pure (Name n)) f1 :===: Type.instantiate (pure (Name n)) f2) ::: Type.instantiate (pure (Name n)) b)
           ctx :|-: (Free (Name n) :$ sp :===: tm2) ::: ty | Just tm1 <- Map.lookup n ctx -> do
             go (ctx :|-: (tm1 Type.$$* sp :===: tm2) ::: ty)
           ctx :|-: (tm1 :===: Free (Name n) :$ sp) ::: ty | Just tm2 <- Map.lookup n ctx -> do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -146,8 +146,8 @@ process :: (Carrier sig m, Effect sig, Member Fresh sig, Member (Reader Gensym) 
 process _S c@(_ :|-: (tm1 :===: tm2) ::: ty)
   | tm1 == tm2 = pure ()
   | s <- Map.restrictKeys _S (metaNames (fvs c)), not (null s) = simplify (applyConstraint s c) >>= enqueueAll
-  | Just (m, sp) <- pattern tm1 = solve (m := Type.lams sp tm2) >> get >>= \ _S -> process _S c
-  | Just (m, sp) <- pattern tm2 = solve (m := Type.lams sp tm1) >> get >>= \ _S -> process _S c
+  | Just (m, sp) <- pattern tm1 = solve (m := Type.lams sp tm2)
+  | Just (m, sp) <- pattern tm2 = solve (m := Type.lams sp tm1)
   | otherwise = block c
 
 block :: (Carrier sig m, Member (State Blocked) sig, MonadFail m) => HomConstraint -> m ()

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -188,7 +188,8 @@ infix 5 :=
 
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
 runElab ty (Elab m) = run . runFail . runFresh . runReader (Root "elab") $ do
-  (constraints, val ::: ty) <- runWriter (runReader (mempty :: Context (Type Meta)) (runReader (fromMaybe Type ty) m))
+  mTy <- Name . Local <$> gensym "meta"
+  (constraints, val ::: ty) <- runWriter (runReader (mempty :: Context (Type Meta)) (runReader (fromMaybe (pure mTy) ty) m))
   subst <- execState (Map.empty :: Map.Map Gensym (Value Meta)) . evalState (Seq.empty :: Seq.Seq Constraint) $ do
     stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set Constraint)) $ do
       enqueueAll constraints

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -189,7 +189,7 @@ infix 5 :=
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
 runElab ty m = run . runFail . runFresh . runReader (Root "elab") $ do
   ty' <- maybe (pure . Meta <$> gensym "meta") pure ty
-  (constraints, res) <- runWriter . runReader (mempty :: Context (Type Meta)) . runReader ty' . unElab $ do
+  (constraints, res) <- runWriter . runReader mempty . runReader ty' . unElab $ do
     val <- exists ty'
     m' <- m
     m' <$ unify (m' :===: val)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -22,8 +22,8 @@ newtype Check a = Check { runCheck :: ReaderC (Type Name) (ReaderC Signature (Re
 newtype Infer a = Infer { runInfer :: ReaderC Signature (ReaderC Gensym (FreshC (FailC VoidC))) a }
   deriving (Applicative, Functor, Monad, MonadFail)
 
-assumption :: Name -> Infer (Typed Name Value)
-assumption v = Infer $ do
+assume :: Name -> Infer (Typed Name Value)
+assume v = Infer $ do
   sig <- ask
   maybe (fail ("Variable not in scope: " <> show v)) (pure . (pure v :::)) (Map.lookup v sig)
 

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -96,8 +96,7 @@ assume' :: Name -> Elab (Value ::: Type Name)
 assume' v = do
   a ::: ty <- goal' >>= exists
   _A <- Elab (lookupVar v)
-  ctx <- context
-  unify (ctx :|- pure v ::: _A :===: a ::: ty)
+  unify (pure v ::: _A :===: a ::: ty)
   pure (a ::: ty)
 
 intro' :: (Name -> Elab (Value ::: Type Name)) -> Elab (Value ::: Type Name)
@@ -107,15 +106,13 @@ intro' body = do
   x <- freshName "intro"
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
-  ctx <- context
-  unify (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)
+  unify (Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)
   pure (a ::: ty)
 
 type'' :: Elab (Value ::: Type Name)
 type'' = do
   a ::: ty <- goal' >>= exists
-  ctx <- context
-  unify (ctx :|- Type ::: Type :===: a ::: ty)
+  unify (Type ::: Type :===: a ::: ty)
   pure (a ::: ty)
 
 
@@ -143,8 +140,8 @@ a ::: ty ||- m = Elab (local (Map.insert a ty) (runElab m))
 
 infix 5 ||-
 
-unify :: Contextual (Equation (Value ::: Type Name)) -> Elab ()
-unify = Elab . tell . Set.singleton
+unify :: Equation (Value ::: Type Name) -> Elab ()
+unify constraint = context >>= Elab . tell . Set.singleton . (:|- constraint)
 
 
 data Equation a

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -92,3 +92,8 @@ data Equation a
   deriving (Eq, Ord, Show)
 
 infix 3 :===:
+
+data Contextual a = Context :|- a
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+infixr 1 :|-

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -144,10 +144,10 @@ step = do
 process :: (Carrier sig m, Effect sig, Member Fresh sig, Member (Reader Gensym) sig, Member (State Blocked) sig, Member (State Queue) sig, Member (State Substitution) sig, MonadFail m) => Substitution -> Constraint -> m ()
 process _S c@(_ :|-: tm1 ::: ty1 :===: tm2 ::: ty2)
   | s <- Map.restrictKeys _S (metaNames (fvs c)), not (null s) = simplify (applyConstraint s c) >>= enqueueAll
-  | Just (m, sp) <- pattern ty1 = solve (m := Type.lams sp ty2)
-  | Just (m, sp) <- pattern ty2 = solve (m := Type.lams sp ty1)
-  | Just (m, sp) <- pattern tm1 = solve (m := Type.lams sp tm2)
-  | Just (m, sp) <- pattern tm2 = solve (m := Type.lams sp tm1)
+  | Just (m, sp) <- pattern ty1 = solve (m := Type.lams sp ty2) >> get >>= \ _S -> process _S c
+  | Just (m, sp) <- pattern ty2 = solve (m := Type.lams sp ty1) >> get >>= \ _S -> process _S c
+  | Just (m, sp) <- pattern tm1 = solve (m := Type.lams sp tm2) >> get >>= \ _S -> process _S c
+  | Just (m, sp) <- pattern tm2 = solve (m := Type.lams sp tm1) >> get >>= \ _S -> process _S c
   | otherwise = block c
 
 block :: (Carrier sig m, Member (State Blocked) sig, MonadFail m) => Constraint -> m ()

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -242,10 +242,6 @@ simplify = execWriter . go
           ctx :|-: (Lam f1 :===: Lam f2) ::: Pi t b -> do
             n <- Local <$> gensym "simplify"
             go (Map.insert n t ctx :|-: (Type.instantiate (pure (Name n)) f1 :===: Type.instantiate (pure (Name n)) f2) ::: Type.instantiate (pure (Name n)) b)
-          ctx :|-: (Free (Name n) :$ sp :===: tm2) ::: ty | Just tm1 <- Map.lookup n ctx -> do
-            go (ctx :|-: (tm1 Type.$$* sp :===: tm2) ::: ty)
-          ctx :|-: (tm1 :===: Free (Name n) :$ sp) ::: ty | Just tm2 <- Map.lookup n ctx -> do
-            go (ctx :|-: (tm1 :===: tm2 Type.$$* sp) ::: ty)
           c@(_ :|-: (t1 :===: t2) ::: _)
             | stuck t1 || stuck t2 -> tell (Set.singleton c)
             | otherwise            -> fail ("unsimplifiable constraint: " ++ pretty c)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -100,6 +100,18 @@ assume' v = do
   Elab (tell (Set.singleton (ctx :|- pure v ::: _A :===: a ::: ty)))
   pure (a ::: ty)
 
+intro' :: (Name -> Elab (Value ::: Type Name)) -> Elab (Value ::: Type Name)
+intro' body = do
+  a ::: ty <- goal' >>= exists
+
+  _A ::: _ <- exists Type
+  x <- Elab (Gensym <$> gensym "intro")
+  _B ::: _ <- x ::: _A ||- exists Type
+  u ::: _ <- x ::: _A ||- goalIs' _B (body x)
+  ctx <- Elab ask
+  Elab (tell (Set.singleton (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)))
+  pure (a ::: ty)
+
 
 exists :: Type Name -> Elab (Value ::: Type Name)
 exists ty = Elab $ do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -124,6 +124,17 @@ pi' t body = do
   unify (Type.pi (x ::: t') b' ::: Type :===: a ::: ty)
   pure (a ::: ty)
 
+($$$) :: Elab (Value ::: Type Name) -> Elab (Value ::: Type Name) -> Elab (Value ::: Type Name)
+f $$$ a = do
+  res <- goal' >>= exists
+  _A ::: _ <- exists Type
+  _B ::: _ <- exists Type
+  x <- freshName "$$"
+  f' ::: _ <- goalIs' (Type.pi (x ::: _A) _B) f
+  a' ::: _ <- goalIs' _A a
+  unify (f' Type.$$ a' ::: _B :===: res)
+  pure res
+
 
 freshName :: String -> Elab Name
 freshName s = Gensym <$> Elab (gensym s)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -111,6 +111,13 @@ intro' body = do
   unify (ctx :|- Type.lam x u ::: Type.pi (x ::: _A) _B :===: a ::: ty)
   pure (a ::: ty)
 
+type'' :: Elab (Value ::: Type Name)
+type'' = do
+  a ::: ty <- goal' >>= exists
+  ctx <- context
+  unify (ctx :|- Type ::: Type :===: a ::: ty)
+  pure (a ::: ty)
+
 
 freshName :: String -> Elab Name
 freshName s = Gensym <$> Elab (gensym s)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -231,3 +231,10 @@ simplify (ctx :|-: c) = execWriter (go c)
         stuck (v ::: ty) = stuckType v || stuckType ty
         stuckType (Free (Meta _) :$ _) = True
         stuckType _                    = False
+
+hetToHom :: HetConstraint -> (HomConstraint, HomConstraint)
+hetToHom (ctx :|-: tm1 ::: ty1 :===: tm2 ::: ty2) =
+  -- FIXME: represent dependency of second on first
+  ( ctx :|-: (ty1 :===: ty2) ::: Type
+  , ctx :|-: (tm1 :===: tm2) ::: ty1
+  )

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -96,8 +96,7 @@ assume' :: Name -> Elab (Value Meta ::: Type Meta)
 assume' v = do
   res <- goal' >>= exists
   _A <- Elab (lookupVar v)
-  unify (pure (Name v) ::: _A :===: res)
-  pure res
+  res <$ unify (pure (Name v) ::: _A :===: res)
 
 intro' :: (Name -> Elab (Value Meta ::: Type Meta)) -> Elab (Value Meta ::: Type Meta)
 intro' body = do
@@ -106,14 +105,12 @@ intro' body = do
   x <- freshName "intro"
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
-  unify (Type.lam (Name x) u ::: Type.pi (Name x ::: _A) _B :===: res)
-  pure res
+  res <$ unify (Type.lam (Name x) u ::: Type.pi (Name x ::: _A) _B :===: res)
 
 type'' :: Elab (Value Meta ::: Type Meta)
 type'' = do
   res <- goal' >>= exists
-  unify (Type ::: Type :===: res)
-  pure res
+  res <$ unify (Type ::: Type :===: res)
 
 pi' :: Elab (Value Meta ::: Type Meta) -> (Name -> Elab (Value Meta ::: Type Meta)) -> Elab (Value Meta ::: Type Meta)
 pi' t body = do
@@ -121,8 +118,7 @@ pi' t body = do
   t' ::: _ <- goalIs' Type t
   x <- freshName "pi"
   b' ::: _ <- x ::: t' ||- goalIs' Type (body x)
-  unify (Type.pi (Name x ::: t') b' ::: Type :===: res)
-  pure res
+  res <$ unify (Type.pi (Name x ::: t') b' ::: Type :===: res)
 
 ($$$) :: Elab (Value Meta ::: Type Meta) -> Elab (Value Meta ::: Type Meta) -> Elab (Value Meta ::: Type Meta)
 f $$$ a = do
@@ -132,8 +128,7 @@ f $$$ a = do
   x <- freshName "$$"
   f' ::: _ <- goalIs' (Type.pi (Name x ::: _A) _B) f
   a' ::: _ <- goalIs' _A a
-  unify (f' Type.$$ a' ::: _B :===: res)
-  pure res
+  res <$ unify (f' Type.$$ a' ::: _B :===: res)
 
 
 freshName :: String -> Elab Name

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -93,16 +93,16 @@ newtype Elab a = Elab { runElab :: ReaderC (Type Name) (ReaderC Context (ReaderC
   deriving (Applicative, Functor, Monad, MonadFail)
 
 assume' :: Name -> Elab (Value ::: Type Name)
-assume' v = Elab $ do
-  a ::: ty <- ask >>= exists
-  _A <- lookupVar v
-  ctx <- ask
-  tell (Set.singleton (ctx :|- pure v ::: _A :===: a ::: ty))
+assume' v = do
+  a ::: ty <- goal' >>= exists
+  _A <- Elab (lookupVar v)
+  ctx <- Elab ask
+  Elab (tell (Set.singleton (ctx :|- pure v ::: _A :===: a ::: ty)))
   pure (a ::: ty)
 
 
-exists :: (Carrier sig m, Member Fresh sig, Member (Reader Context) sig, Member (Reader Gensym) sig) => Type Name -> m (Value ::: Type Name)
-exists ty = do
+exists :: Type Name -> Elab (Value ::: Type Name)
+exists ty = Elab $ do
   ctx <- ask
   -- FIXME: add meta names
   n <- Gensym <$> gensym "_meta_"

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -94,7 +94,7 @@ runCheck' :: Context (Type Name) -> Type Name -> Check a -> Either String a
 runCheck' sig ty = runInfer' sig . ascribe ty
 
 
-newtype Elab a = Elab (ReaderC (Type Meta) (ReaderC (Context (Type Meta)) (WriterC (Set.Set Constraint) (ReaderC Gensym (FreshC (FailC VoidC))))) a)
+newtype Elab a = Elab { unElab :: ReaderC (Type Meta) (ReaderC (Context (Type Meta)) (WriterC (Set.Set Constraint) (ReaderC Gensym (FreshC (FailC VoidC))))) a }
   deriving (Applicative, Functor, Monad, MonadFail)
 
 assume' :: Name -> Elab (Value Meta ::: Type Meta)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -89,7 +89,7 @@ runCheck' :: Context (Type Name) -> Type Name -> Check a -> Either String a
 runCheck' sig ty = runInfer' sig . ascribe ty
 
 
-newtype Elab a = Elab { runElab :: ReaderC (Type Meta) (ReaderC (Context (Type Meta)) (ReaderC Gensym (FreshC (WriterC (Set.Set (Contextual (Equation (Value Meta ::: Type Meta)))) (FailC VoidC))))) a }
+newtype Elab a = Elab (ReaderC (Type Meta) (ReaderC (Context (Type Meta)) (ReaderC Gensym (FreshC (WriterC (Set.Set (Contextual (Equation (Value Meta ::: Type Meta)))) (FailC VoidC))))) a)
   deriving (Applicative, Functor, Monad, MonadFail)
 
 assume' :: Name -> Elab (Value Meta ::: Type Meta)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -104,7 +104,7 @@ intro' :: (Name -> Elab (Value ::: Type Name)) -> Elab (Value ::: Type Name)
 intro' body = do
   a ::: ty <- goal' >>= exists
   _A ::: _ <- exists Type
-  x <- gensym' "intro"
+  x <- freshName "intro"
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
   ctx <- Elab ask
@@ -112,8 +112,8 @@ intro' body = do
   pure (a ::: ty)
 
 
-gensym' :: String -> Elab Name
-gensym' s = Gensym <$> Elab (gensym s)
+freshName :: String -> Elab Name
+freshName s = Gensym <$> Elab (gensym s)
 
 exists :: Type Name -> Elab (Value ::: Type Name)
 exists ty = Elab $ do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -92,6 +92,14 @@ runCheck' sig ty = runInfer' sig . ascribe ty
 newtype Elab a = Elab { runElab :: ReaderC Context (ReaderC Gensym (FreshC (WriterC (Set.Set (Contextual (Equation (Value ::: Type Name)))) (FailC VoidC)))) a }
   deriving (Applicative, Functor, Monad, MonadFail)
 
+assume' :: Name ::: Type Name -> Elab (Value ::: Type Name)
+assume' (v ::: ty) = Elab $ do
+  a ::: ty <- exists ty
+  _A <- lookupVar v
+  ctx <- ask
+  tell (Set.singleton (ctx :|- pure v ::: _A :===: a ::: ty))
+  pure (a ::: ty)
+
 
 exists :: (Carrier sig m, Member Fresh sig, Member (Reader Context) sig, Member (Reader Gensym) sig) => Type Name -> m (Value ::: Type Name)
 exists ty = do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -14,6 +14,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Elab.Name
+import Elab.Pretty
 import Elab.Stack
 import Elab.Type (Type(..))
 import qualified Elab.Type as Type
@@ -117,6 +118,10 @@ data Solution
   deriving (Eq, Ord, Show)
 
 infix 5 :=
+
+instance Pretty Solution where
+  prettys (n := v) = prettys n . showString " := " . prettys v
+
 
 runElab :: Maybe (Type Meta) -> Elab (Value Meta ::: Type Meta) -> Either String (Value Name ::: Type Name)
 runElab ty m = run . runFail . runFresh . runReader (Root "elab") $ do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -66,6 +66,11 @@ f $$ a = do
   res <$ unify (f' Type.$$ a' ::: _B :===: res)
 
 
+expect :: Value Meta ::: Type Meta -> Elab (Value Meta ::: Type Meta)
+expect exp = do
+  res <- goal >>= exists
+  res <$ unify (exp :===: res)
+
 freshName :: String -> Elab Name
 freshName s = Local <$> Elab (gensym s)
 

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -94,35 +94,35 @@ newtype Elab a = Elab { runElab :: ReaderC (Type Meta) (ReaderC (Context (Type M
 
 assume' :: Name -> Elab (Value Meta ::: Type Meta)
 assume' v = do
-  a ::: ty <- goal' >>= exists
+  res <- goal' >>= exists
   _A <- Elab (lookupVar v)
-  unify (pure (Name v) ::: _A :===: a ::: ty)
-  pure (a ::: ty)
+  unify (pure (Name v) ::: _A :===: res)
+  pure res
 
 intro' :: (Name -> Elab (Value Meta ::: Type Meta)) -> Elab (Value Meta ::: Type Meta)
 intro' body = do
-  a ::: ty <- goal' >>= exists
+  res <- goal' >>= exists
   _A ::: _ <- exists Type
   x <- freshName "intro"
   _B ::: _ <- x ::: _A ||- exists Type
   u ::: _ <- x ::: _A ||- goalIs' _B (body x)
-  unify (Type.lam (Name x) u ::: Type.pi (Name x ::: _A) _B :===: a ::: ty)
-  pure (a ::: ty)
+  unify (Type.lam (Name x) u ::: Type.pi (Name x ::: _A) _B :===: res)
+  pure res
 
 type'' :: Elab (Value Meta ::: Type Meta)
 type'' = do
-  a ::: ty <- goal' >>= exists
-  unify (Type ::: Type :===: a ::: ty)
-  pure (a ::: ty)
+  res <- goal' >>= exists
+  unify (Type ::: Type :===: res)
+  pure res
 
 pi' :: Elab (Value Meta ::: Type Meta) -> (Name -> Elab (Value Meta ::: Type Meta)) -> Elab (Value Meta ::: Type Meta)
 pi' t body = do
-  a ::: ty <- goal' >>= exists
+  res <- goal' >>= exists
   t' ::: _ <- goalIs' Type t
   x <- freshName "pi"
   b' ::: _ <- x ::: t' ||- goalIs' Type (body x)
-  unify (Type.pi (Name x ::: t') b' ::: Type :===: a ::: ty)
-  pure (a ::: ty)
+  unify (Type.pi (Name x ::: t') b' ::: Type :===: res)
+  pure res
 
 ($$$) :: Elab (Value Meta ::: Type Meta) -> Elab (Value Meta ::: Type Meta) -> Elab (Value Meta ::: Type Meta)
 f $$$ a = do

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -5,8 +5,10 @@ import Control.Effect
 import Control.Effect.Fail
 import Control.Effect.Fresh
 import Control.Effect.Reader
+import Control.Effect.Writer
 import Control.Monad (unless)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Elab.Name
 import Elab.Type (Type(..))
 import qualified Elab.Type as Type
@@ -87,6 +89,8 @@ runCheck' :: Context -> Type Name -> Check a -> Either String a
 runCheck' sig ty = runInfer' sig . ascribe ty
 
 
+newtype Elab a = Elab { runElab :: ReaderC Context (ReaderC Gensym (FreshC (WriterC (Set.Set (Contextual (Equation (Value ::: Type Name)))) (FailC VoidC)))) a }
+  deriving (Applicative, Functor, Monad, MonadFail)
 
 
 exists :: (Carrier sig m, Member Fresh sig, Member (Reader Context) sig, Member (Reader Gensym) sig) => Type Name -> m (Value ::: Type Name)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -199,7 +199,7 @@ runElab ty m = run . runFail . runFresh . runReader (Root "elab") $ do
   pure (val' ::: ty')
 
 solver :: (Carrier sig m, Effect sig, Member Fresh sig, Member (Reader Gensym) sig, MonadFail m) => Set.Set Constraint -> m Substitution
-solver constraints = execState (Map.empty :: Map.Map Gensym (Value Meta)) . evalState (Seq.empty :: Seq.Seq Constraint) $ do
+solver constraints = execState Map.empty . evalState (Seq.empty :: Seq.Seq Constraint) $ do
   stuck <- fmap fold . execState (Map.empty :: Map.Map Gensym (Set.Set Constraint)) $ do
     enqueueAll constraints
     step

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -175,7 +175,7 @@ free _               = Nothing
 
 solve :: (Carrier sig m, Member (State Blocked) sig, Member (State Queue) sig, Member (State Substitution) sig) => Solution -> m ()
 solve (m := v) = do
-  modify (Map.insert m v)
+  modify (Map.insert m v . fmap (applyType (Map.singleton m v)))
   cs <- gets (fromMaybe Set.empty . Map.lookup m)
   enqueueAll cs
   modify (Map.delete m :: Blocked -> Blocked)

--- a/src/Elab/Elab.hs
+++ b/src/Elab/Elab.hs
@@ -237,9 +237,9 @@ simplify (ctx :|-: c) = execWriter (go c)
         stuckType (Free (Meta _) :$ _) = True
         stuckType _                    = False
 
-hetToHom :: HetConstraint -> (HomConstraint, HomConstraint)
-hetToHom (ctx :|-: tm1 ::: ty1 :===: tm2 ::: ty2) =
+hetToHom :: HetConstraint -> Set.Set HomConstraint
+hetToHom (ctx :|-: tm1 ::: ty1 :===: tm2 ::: ty2) = Set.fromList
   -- FIXME: represent dependency of second on first
-  ( ctx :|-: (ty1 :===: ty2) ::: Type
+  [ ctx :|-: (ty1 :===: ty2) ::: Type
   , ctx :|-: (tm1 :===: tm2) ::: ty1
-  )
+  ]

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -13,7 +13,7 @@ data Head a
 
 data Name
   = Global String
-  | Gensym Gensym
+  | Local  Gensym
   deriving (Eq, Ord, Show)
 
 

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -17,6 +17,12 @@ data Name
   deriving (Eq, Ord, Show)
 
 
+data MetaName
+  = Name Name
+  | Meta Gensym
+  deriving (Eq, Ord, Show)
+
+
 data Gensym
   = Root String
   | Gensym :/ (String, Int)

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -27,6 +27,10 @@ data Meta
   | Meta Gensym
   deriving (Eq, Ord, Show)
 
+instance Pretty Meta where
+  prettys (Name n) = prettys n
+  prettys (Meta g) = showChar '@' . prettys g
+
 
 data Gensym
   = Root String

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -63,3 +63,7 @@ infix 6 :::
 
 instance (Pretty a, Pretty b) => Pretty (a ::: b) where
   prettys (a ::: b) = prettys a . showString " : " . prettys b
+
+
+data Incr a = Z | S a
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -68,6 +68,14 @@ instance (Pretty a, Pretty b) => Pretty (a ::: b) where
 data Incr a = Z | S a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+match :: Eq a => a -> a -> Incr a
+match x y | x == y    = Z
+          | otherwise = S y
+
+subst :: a -> Incr a -> a
+subst a Z     = a
+subst _ (S a) = a
+
 instance Pretty a => Pretty (Incr a) where
   prettys Z = showChar 'Z'
   prettys (S a) = showString "S " . prettys a

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -11,6 +11,10 @@ data Head a
   | Bound Int
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+instance Pretty a => Pretty (Head a) where
+  prettys (Free a) = prettys a
+  prettys (Bound i) = shows i
+
 
 data Name
   = Global String

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, FlexibleContexts #-}
+{-# LANGUAGE DeriveTraversable, FlexibleContexts, TypeOperators #-}
 module Elab.Name where
 
 import Control.Effect
@@ -31,3 +31,9 @@ infixl 6 //
 
 gensym :: (Carrier sig m, Member Fresh sig, Member (Reader Gensym) sig) => String -> m Gensym
 gensym s = (:/) <$> ask <*> ((,) s <$> fresh)
+
+
+data a ::: b = a ::: b
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+infix 6 :::

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -3,7 +3,7 @@ module Elab.Name where
 
 import Control.Effect
 import Control.Effect.Fresh
-import Control.Effect.Reader
+import Control.Effect.Reader hiding (Local)
 import Elab.Pretty
 
 data Head a
@@ -16,6 +16,10 @@ data Name
   = Global String
   | Local  Gensym
   deriving (Eq, Ord, Show)
+
+instance Pretty Name where
+  prettys (Global s) = showChar '$' . showString s
+  prettys (Local n)  = showChar '_' . prettys n
 
 
 data Meta

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -4,6 +4,7 @@ module Elab.Name where
 import Control.Effect
 import Control.Effect.Fresh
 import Control.Effect.Reader
+import Elab.Pretty
 
 data Head a
   = Free a
@@ -43,3 +44,6 @@ data a ::: b = a ::: b
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 infix 6 :::
+
+instance (Pretty a, Pretty b) => Pretty (a ::: b) where
+  prettys (a ::: b) = prettys a . showString " : " . prettys b

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -67,3 +67,7 @@ instance (Pretty a, Pretty b) => Pretty (a ::: b) where
 
 data Incr a = Z | S a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+instance Pretty a => Pretty (Incr a) where
+  prettys Z = showChar 'Z'
+  prettys (S a) = showString "S " . prettys a

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -17,7 +17,7 @@ data Name
   deriving (Eq, Ord, Show)
 
 
-data MetaName
+data Meta
   = Name Name
   | Meta Gensym
   deriving (Eq, Ord, Show)

--- a/src/Elab/Name.hs
+++ b/src/Elab/Name.hs
@@ -29,6 +29,10 @@ data Gensym
   | Gensym :/ (String, Int)
   deriving (Eq, Ord, Show)
 
+instance Pretty Gensym where
+  prettys (Root s) = showString s
+  prettys (root :/ (leaf, i)) = prettys root . showChar '.' . showString leaf . shows i
+
 infixl 6 :/
 
 (//) :: Gensym -> String -> Gensym

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -2,3 +2,6 @@ module Elab.Pretty where
 
 class Pretty a where
   prettys :: a -> ShowS
+
+pretty :: Pretty a => a -> String
+pretty = ($ "") . prettys

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -12,6 +12,9 @@ class Pretty a where
 pretty :: Pretty a => a -> String
 pretty = ($ "") . prettys
 
+prettyPrint :: Pretty a => a -> IO ()
+prettyPrint = putStrLn . pretty
+
 instance Pretty a => Pretty [a] where
   prettys = showListWith prettys
 

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -1,7 +1,12 @@
 module Elab.Pretty where
 
+import Text.Show
+
 class Pretty a where
   prettys :: a -> ShowS
 
 pretty :: Pretty a => a -> String
 pretty = ($ "") . prettys
+
+instance Pretty a => Pretty [a] where
+  prettys = showListWith prettys

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -1,1 +1,4 @@
 module Elab.Pretty where
+
+class Pretty a where
+  prettys :: a -> ShowS

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -1,6 +1,8 @@
 module Elab.Pretty where
 
+import Data.Foldable (toList)
 import qualified Data.Map as Map
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Text.Show
 
@@ -19,3 +21,6 @@ instance (Pretty k, Pretty v) => Pretty (Map.Map k v) where
 
 instance Pretty a => Pretty (Set.Set a) where
   prettys = showListWith prettys . Set.toList
+
+instance Pretty a => Pretty (Seq.Seq a) where
+  prettys = showListWith prettys . toList

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -1,6 +1,7 @@
 module Elab.Pretty where
 
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Text.Show
 
 class Pretty a where
@@ -15,3 +16,6 @@ instance Pretty a => Pretty [a] where
 instance (Pretty k, Pretty v) => Pretty (Map.Map k v) where
   prettys = showListWith prettyPair . Map.toList
     where prettyPair (k, v) = prettys k . showString " => " . prettys v
+
+instance Pretty a => Pretty (Set.Set a) where
+  prettys = showListWith prettys . Set.toList

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -1,5 +1,6 @@
 module Elab.Pretty where
 
+import qualified Data.Map as Map
 import Text.Show
 
 class Pretty a where
@@ -10,3 +11,7 @@ pretty = ($ "") . prettys
 
 instance Pretty a => Pretty [a] where
   prettys = showListWith prettys
+
+instance (Pretty k, Pretty v) => Pretty (Map.Map k v) where
+  prettys = showListWith prettyPair . Map.toList
+    where prettyPair (k, v) = prettys k . showString " => " . prettys v

--- a/src/Elab/Pretty.hs
+++ b/src/Elab/Pretty.hs
@@ -1,0 +1,1 @@
+module Elab.Pretty where

--- a/src/Elab/Stack.hs
+++ b/src/Elab/Stack.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DeriveTraversable #-}
 module Elab.Stack where
 
+import Data.Foldable (toList)
+import Elab.Pretty
+
 data Stack a = Nil | Stack a :> a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
@@ -14,3 +17,6 @@ instance Semigroup (Stack a) where
 instance Monoid (Stack a) where
   mempty = Nil
   mappend = (<>)
+
+instance Pretty a => Pretty (Stack a) where
+  prettys = prettys . toList

--- a/src/Elab/Term.hs
+++ b/src/Elab/Term.hs
@@ -16,9 +16,6 @@ data Term a
 newtype Scope a = Scope (Term a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
-free :: a -> Term a
-free = Head . Free
-
 lam :: Eq a => a -> Term a -> Term a
 lam n b = Lam (bind n b)
 

--- a/src/Elab/Term.hs
+++ b/src/Elab/Term.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, LambdaCase, TypeOperators #-}
+{-# LANGUAGE DeriveTraversable, LambdaCase, RankNTypes, ScopedTypeVariables, TypeOperators #-}
 module Elab.Term where
 
 import Control.Monad (ap)
@@ -6,60 +6,70 @@ import Elab.Name
 import Prelude hiding (pi)
 
 data Term a
-  = Var (Head a)
+  = Var a
   | Lam (Scope a)
   | Term a :$ Term a
   | Type
   | Pi (Term a) (Scope a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
-newtype Scope a = Scope (Term a)
+newtype Scope a = Scope (Term (Incr a))
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 lam :: Eq a => a -> Term a -> Term a
-lam n b = Lam (bind n b)
+lam n b = Lam (Scope (match n <$> b))
 
 lams :: (Eq a, Foldable t) => t a -> Term a -> Term a
 lams names body = foldr lam body names
 
 pi :: Eq a => a ::: Term a -> Term a -> Term a
-pi (n ::: t) b = Pi t (bind n b)
+pi (n ::: t) b = Pi t (Scope (match n <$> b))
 
 pis :: (Eq a, Foldable t) => t (a ::: Term a) -> Term a -> Term a
 pis names body = foldr pi body names
 
 
+gfoldT :: forall m n b
+       .  (forall a . m a -> n a)
+       -> (forall a . n (Incr a) -> n a)
+       -> (forall a . n a -> n a -> n a)
+       -> (forall a . n a)
+       -> (forall a . n a -> n (Incr a) -> n a)
+       -> (forall a . Incr (m a) -> m (Incr a))
+       -> Term (m b)
+       -> n b
+gfoldT var lam app ty pi dist = go
+  where go :: Term (m x) -> n x
+        go = \case
+          Var a -> var a
+          Lam (Scope b) -> lam (go (dist <$> b))
+          f :$ a -> app (go f) (go a)
+          Type -> ty
+          Pi t (Scope b) -> pi (go t) (go (dist <$> b))
+
+joinT :: Term (Term a) -> Term a
+joinT = gfoldT id (Lam . Scope) (:$) Type (\ t -> Pi t . Scope) distT
+
+distT :: Incr (Term a) -> Term (Incr a)
+distT Z     = Var Z
+distT (S t) = S <$> t
+
+
 -- | Bind occurrences of a 'Name' in a 'Term' term, producing a 'Scope' in which the 'Name' is bound.
 bind :: Eq a => a -> Term a -> Scope a
-bind name = Scope . substIn (\ i v -> Var $ case v of
-  Bound j -> Bound j
-  Free  n -> if name == n then Bound i else Free n)
+bind name = Scope . fmap (match name)
 
 -- | Substitute a 'Term' term for the free variable in a given 'Scope', producing a closed 'Term' term.
 instantiate :: Term a -> Scope a -> Term a
-instantiate image (Scope b) = substIn (\ i v -> case v of
-  Bound j -> if i == j then image else Var (Bound j)
-  Free  n -> pure n) b
-
-substIn :: (Int -> Head a -> Term b)
-        -> Term a
-        -> Term b
-substIn var = go 0
-  where go i (Var h)          = var i h
-        go i (Lam (Scope b))  = Lam (Scope (go (succ i) b))
-        go i (f :$ a)         = go i f :$ go i a
-        go _ Type             = Type
-        go i (Pi t (Scope b)) = Pi (go i t) (Scope (go (succ i) b))
+instantiate t (Scope b) = b >>= subst t . fmap Var
 
 
 instance Applicative Term where
-  pure = Var . Free
+  pure = Var
   (<*>) = ap
 
 instance Monad Term where
-  a >>= f = substIn (const (\case
-    Free a' -> f a'
-    Bound i -> Var (Bound i))) a
+  a >>= f = joinT (f <$> a)
 
 
 identityT :: Term Name

--- a/src/Elab/Term.hs
+++ b/src/Elab/Term.hs
@@ -66,7 +66,7 @@ instance Monad Term where
 
 
 identityT :: Term Name
-identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "y"))))
+identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "x"))))
 
 identity :: Term Name
 identity = lam (Local (Root "x")) (lam (Local (Root "y")) (pure (Local (Root "y"))))

--- a/src/Elab/Term.hs
+++ b/src/Elab/Term.hs
@@ -63,3 +63,7 @@ instance Monad Term where
   a >>= f = substIn (const (\case
     Free a' -> f a'
     Bound i -> Head (Bound i))) a
+
+
+identity :: Term Name
+identity = lam (Local (Root "x")) (lam (Local (Root "y")) (pure (Local (Root "y"))))

--- a/src/Elab/Term.hs
+++ b/src/Elab/Term.hs
@@ -65,5 +65,8 @@ instance Monad Term where
     Bound i -> Head (Bound i))) a
 
 
+identityT :: Term Name
+identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "y"))))
+
 identity :: Term Name
 identity = lam (Local (Root "x")) (lam (Local (Root "y")) (pure (Local (Root "y"))))

--- a/src/Elab/Term.hs
+++ b/src/Elab/Term.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, LambdaCase #-}
+{-# LANGUAGE DeriveTraversable, LambdaCase, TypeOperators #-}
 module Elab.Term where
 
 import Control.Monad (ap)
@@ -25,16 +25,11 @@ lam n b = Lam (bind n b)
 lams :: (Eq a, Foldable t) => t a -> Term a -> Term a
 lams names body = foldr lam body names
 
-pi :: Eq a => Typed a -> Term a -> Term a
+pi :: Eq a => a ::: Term a -> Term a -> Term a
 pi (n ::: t) b = Pi t (bind n b)
 
-pis :: (Eq a, Foldable t) => t (Typed a) -> Term a -> Term a
+pis :: (Eq a, Foldable t) => t (a ::: Term a) -> Term a -> Term a
 pis names body = foldr pi body names
-
-data Typed a = a ::: Term a
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-infix 6 :::
 
 
 -- | Bind occurrences of a 'Name' in a 'Term' term, producing a 'Scope' in which the 'Name' is bound.

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -83,7 +83,7 @@ instance Monad Type where
     Bound i -> Bound i :$ mempty)) a
 
 identityT :: Type Name
-identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "y"))))
+identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "x"))))
 
 identity :: Type Name
 identity = lam (Local (Root "x")) (lam (Local (Root "y")) (pure (Local (Root "y"))))

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, LambdaCase #-}
+{-# LANGUAGE DeriveTraversable, LambdaCase, TypeOperators #-}
 module Elab.Type where
 
 import Control.Monad (ap)
@@ -18,7 +18,7 @@ newtype Scope a = Scope (Type a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 
-data Typed v a = a ::: Type v
+data a ::: b = a ::: b
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 infix 6 :::
@@ -29,10 +29,10 @@ lam n b = Lam (bind n b)
 lams :: (Eq a, Foldable t) => t a -> Type a -> Type a
 lams names body = foldr lam body names
 
-pi :: Eq a => Typed a a -> Type a -> Type a
+pi :: Eq a => a ::: Type a -> Type a -> Type a
 pi (n ::: t) b = Pi t (bind n b)
 
-pis :: (Eq a, Foldable t) => t (Typed a a) -> Type a -> Type a
+pis :: (Eq a, Foldable t) => t (a ::: Type a) -> Type a -> Type a
 pis names body = foldr pi body names
 
 ($$) :: Type a -> Type a -> Type a

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -2,8 +2,9 @@
 module Elab.Type where
 
 import Control.Monad (ap)
-import Data.Foldable (foldl')
+import Data.Foldable (foldl', toList)
 import Elab.Name
+import Elab.Pretty
 import Elab.Stack
 import Prelude hiding (pi)
 
@@ -14,8 +15,18 @@ data Type a
   | Head a :$ Stack (Type a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+instance Pretty a => Pretty (Type a) where
+  prettys (h :$ Nil) = prettys h
+  prettys (h :$ sp)  = prettys h . showChar ' ' . prettys (toList sp)
+  prettys Type       = showString "Type"
+  prettys (Lam b)    = showString "λ" . prettys b
+  prettys (Pi t b)   = showString "π" . prettys t . showString " -> " . prettys b
+
 newtype Scope a = Scope (Type a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+instance Pretty a => Pretty (Scope a) where
+  prettys (Scope a) = prettys a
 
 
 lam :: Eq a => a -> Type a -> Type a

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -70,3 +70,9 @@ instance Monad Type where
   a >>= f = substIn (const (\case
     Free a' -> f a'
     Bound i -> Bound i :$ mempty)) a
+
+identityT :: Type Name
+identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "y"))))
+
+identity :: Type Name
+identity = lam (Local (Root "x")) (lam (Local (Root "y")) (pure (Local (Root "y"))))

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -19,8 +19,8 @@ instance Pretty a => Pretty (Type a) where
   prettys (h :$ Nil) = prettys h
   prettys (h :$ sp)  = prettys h . showChar ' ' . prettys (toList sp)
   prettys Type       = showString "Type"
-  prettys (Lam b)    = showString "λ" . prettys b
-  prettys (Pi t b)   = showString "π" . prettys t . showString " -> " . prettys b
+  prettys (Lam b)    = showString "λ " . showParen True (prettys b)
+  prettys (Pi t b)   = showString "π " . prettys t . showString " . " . prettys b
 
 newtype Scope a = Scope (Type a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, LambdaCase, TypeOperators #-}
+{-# LANGUAGE DeriveTraversable, LambdaCase, RankNTypes, ScopedTypeVariables, TypeOperators #-}
 module Elab.Type where
 
 import Control.Monad (ap)
@@ -12,7 +12,7 @@ data Type a
   = Type
   | Lam          (Scope a)
   | Pi  (Type a) (Scope a)
-  | Head a :$ Stack (Type a)
+  | a :$ Stack (Type a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 instance Pretty a => Pretty (Type a) where
@@ -22,7 +22,7 @@ instance Pretty a => Pretty (Type a) where
   prettys (Lam b)    = showString "λ " . showParen True (prettys b)
   prettys (Pi t b)   = showString "π " . prettys t . showString " . " . prettys b
 
-newtype Scope a = Scope (Type a)
+newtype Scope a = Scope (Type (Incr a))
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 instance Pretty a => Pretty (Scope a) where
@@ -51,36 +51,44 @@ Type    $$ _ = error "illegal application of Type"
 v $$* sp = foldl' ($$) v sp
 
 
+gfoldT :: forall m n b
+       .  (forall a . n (Incr a) -> n a)
+       -> (forall a . m a -> Stack (n a) -> n a)
+       -> (forall a . n a)
+       -> (forall a . n a -> n (Incr a) -> n a)
+       -> (forall a . Incr (m a) -> m (Incr a))
+       -> Type (m b)
+       -> n b
+gfoldT lam app ty pi dist = go
+  where go :: Type (m x) -> n x
+        go = \case
+          Lam (Scope b) -> lam (go (dist <$> b))
+          f :$ a -> app f (fmap go a)
+          Type -> ty
+          Pi t (Scope b) -> pi (go t) (go (dist <$> b))
+
+joinT :: Type (Type a) -> Type a
+joinT = gfoldT (Lam . Scope) ($$*) Type (\ t -> Pi t . Scope) distT
+
+distT :: Incr (Type a) -> Type (Incr a)
+distT Z     = pure Z
+distT (S t) = S <$> t
+
 -- | Bind occurrences of a 'Name' in a 'Type' term, producing a 'Scope' in which the 'Name' is bound.
 bind :: Eq a => a -> Type a -> Scope a
-bind name = Scope . substIn (\ i v -> (:$ mempty) $ case v of
-  Bound j -> Bound j
-  Free  n -> if name == n then Bound i else Free n)
+bind name = Scope . fmap (match name)
 
 -- | Substitute a 'Type' term for the free variable in a given 'Scope', producing a closed 'Type' term.
 instantiate :: Type a -> Scope a -> Type a
-instantiate image (Scope b) = substIn (\ i v -> case v of
-  Bound j -> if i == j then image else Bound j :$ mempty
-  Free  n -> pure n) b
-
-substIn :: (Int -> Head a -> Type b)
-        -> Type a
-        -> Type b
-substIn var = go 0
-  where go i (Lam (Scope b))  = Lam (Scope (go (succ i) b))
-        go i (f :$ a)         = var i f $$* fmap (go i) a
-        go _ Type             = Type
-        go i (Pi t (Scope b)) = Pi (go i t) (Scope (go (succ i) b))
+instantiate t (Scope b) = b >>= subst t . fmap pure
 
 
 instance Applicative Type where
-  pure a = Free a :$ mempty
+  pure a = a :$ Nil
   (<*>) = ap
 
 instance Monad Type where
-  a >>= f = substIn (const (\case
-    Free a' -> f a'
-    Bound i -> Bound i :$ mempty)) a
+  a >>= f = joinT (f <$> a)
 
 identityT :: Type Name
 identityT = pi (Local (Root "x") ::: Type) (pi (Local (Root "y") ::: pure (Local (Root "x"))) (pure (Local (Root "x"))))

--- a/src/Elab/Type.hs
+++ b/src/Elab/Type.hs
@@ -18,11 +18,6 @@ newtype Scope a = Scope (Type a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 
-data a ::: b = a ::: b
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-infix 6 :::
-
 lam :: Eq a => a -> Type a -> Type a
 lam n b = Lam (bind n b)
 


### PR DESCRIPTION
This PR implements the basic flow described in _Type Checking through Unification_. We now have a proper (taken-to-bits) elaborator and higher-order dynamic pattern unifier.

I also went to the effort of changing all the syntax à la _de Bruijn notation as a nested datatype_.